### PR TITLE
fr: Fix plural handling for "million" and suffixes above

### DIFF
--- a/Numbers/Words/Locale/fr.php
+++ b/Numbers/Words/Locale/fr.php
@@ -432,7 +432,7 @@ class Numbers_Words_Locale_fr extends Numbers_Words
             // skip processment for empty groups
             if ($number!='000') {
                 if ($number!=1 || $pow!=2) {
-                    $ret .= $this->_showDigitsGroup($number, $i+1==$sizeof_numgroups).$this->_sep;
+                    $ret .= $this->_showDigitsGroup($number, $i+1==$sizeof_numgroups||$pow>2).$this->_sep;
                 }
                 $ret .= $this->_exponent[($pow-1)*3];
                 if ($pow>2 && $number>1) {


### PR DESCRIPTION
Because 400000000 should be "quatre cents millions" not "quatre cent millions"
since suffixes "million", "milliard" and above are names not adjectives, and
therefore must have the plural form.

Source: http://leconjugueur.lefigaro.fr/frlesnombres.php
