### PR TITLE
Add toCurrencyWords to Locale_fr

### DIFF
--- a/Numbers/Words/Locale/fr.php
+++ b/Numbers/Words/Locale/fr.php
@@ -249,6 +249,26 @@ class Numbers_Words_Locale_fr extends Numbers_Words
       300 => 'novemnonagintillion',
       303 => 'centillion'
         );
+        
+        /**
+     * The currency names (based on the below links,
+     * informations from central bank websites and on encyclopedias)
+     *
+     * @var array
+     * @link http://30-03-67.dreamstation.com/currency_alfa.htm World Currency Information
+     * @link http://www.jhall.demon.co.uk/currency/by_abbrev.html World currencies
+     * @link http://www.shoestring.co.kr/world/p.visa/change.htm Currency names in English
+     * @access private
+     */
+    var $_currency_names = array(
+      'EUR' => array(array('euro'), array('centime')),
+    );
+    /**
+     * The default currency name
+     * @var string
+     * @access public
+     */
+    var $def_currency = 'EUR'; // Euro
     // }}}
 
     // {{{ _splitNumber()
@@ -443,6 +463,66 @@ class Numbers_Words_Locale_fr extends Numbers_Words
         }
 
         return rtrim($ret, $this->_sep);
+    }
+    // }}}
+    // {{{ toCurrencyWords()
+
+    /**
+     * Converts a currency value to its word representation
+     * (with monetary units) in English language
+     *
+     * @param integer $int_curr         An international currency symbol
+     *                                  as defined by the ISO 4217 standard (three characters)
+     * @param integer $decimal          A money total amount without fraction part (e.g. amount of dollars)
+     * @param integer $fraction         Fractional part of the money amount (e.g. amount of cents)
+     *                                  Optional. Defaults to false.
+     * @param integer $convert_fraction Convert fraction to words (left as numeric if set to false).
+     *                                  Optional. Defaults to true.
+     *
+     * @return string  The corresponding word representation for the currency
+     *
+     * @access public
+     * @author Piotr Klaban <makler@man.torun.pl>
+     * @since  Numbers_Words 0.13.1
+     */
+    function toCurrencyWords($int_curr, $decimal, $fraction = false, $convert_fraction = true)
+    {
+        $int_curr = strtoupper($int_curr);
+        if (!isset($this->_currency_names[$int_curr])) {
+            $int_curr = $this->def_currency;
+        }
+        $curr_names = $this->_currency_names[$int_curr];
+
+        $ret = trim($this->_toWords($decimal));
+        $lev = ($decimal == 1) ? 0 : 1;
+        if ($lev > 0) {
+            if (count($curr_names[0]) > 1) {
+                $ret .= $this->_sep . $curr_names[0][$lev];
+            } else {
+                $ret .= $this->_sep . $curr_names[0][0] . 's';
+            }
+        } else {
+            $ret .= $this->_sep . $curr_names[0][0];
+        }
+
+        if ($fraction !== false) {
+            if ($convert_fraction) {
+                $ret .= $this->_sep . $this->_and . $this->_sep . trim($this->_toWords($fraction));
+            } else {
+                $ret .= $this->_sep . $this->_and . $this->_sep . $fraction;
+            }
+            $lev = ($fraction == 1) ? 0 : 1;
+            if ($lev > 0) {
+                if (count($curr_names[1]) > 1) {
+                    $ret .= $this->_sep . $curr_names[1][$lev];
+                } else {
+                    $ret .= $this->_sep . $curr_names[1][0] . 's';
+                }
+            } else {
+                $ret .= $this->_sep . $curr_names[1][0];
+            }
+        }
+        return $ret;
     }
     // }}}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pear/numbers_words",
-    "version": "locale_fr",
+    "version": "dev-locale-fr",
     "description": "Allows converting numbers written in arabic digits to words in several languages. You can convert an integer between -infinity and infinity.",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pear/numbers_words",
-    "version": "locale_fr"
+    "version": "locale_fr",
     "description": "Allows converting numbers written in arabic digits to words in several languages. You can convert an integer between -infinity and infinity.",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "pear/numbers_words",
+    "version": "locale_fr"
     "description": "Allows converting numbers written in arabic digits to words in several languages. You can convert an integer between -infinity and infinity.",
     "type": "library",
     "keywords": [


### PR DESCRIPTION
Added toCurrencyWords for the french language (at the moment, it's working only with EUR €).

Example :

``` php
echo \Numbers_Words::toCurrency(250.62, "fr", "EUR");
// "deux cent cinquante euros et soixante-deux centimes"
```
