### PR TITLE
Added method

### DIFF
--- a/Numbers/Words.php
+++ b/Numbers/Words.php
@@ -296,7 +296,7 @@ class Numbers_Words
             }
         }
 
-        return trim($obj->toAccountableWords($intCurr, $currency[0], $currency[1]));
+        return trim($obj->toAccountableWords($intCurr, $currency[0], $currency[1], false));
     }
     // }}}
 

--- a/Numbers/Words.php
+++ b/Numbers/Words.php
@@ -215,6 +215,92 @@ class Numbers_Words
     }
     // }}}
 
+    // {{{ toAccountable()
+    /**
+     * Converts a currency value to word representation (1.02 => one dollar with 02/100)
+     * If the number has not any fraction part, the "cents" number is omitted.
+     * If you still want a fraction part, then use a 0 digit (ie: 12.0 => twelve dollar with 0/100)
+     *
+     * @param float  $num      A float/integer/string number representing currency value
+     *
+     * @param string $locale   Language name abbreviation. Optional. Defaults to en_US.
+     *
+     * @param string $intCurr  International currency symbol
+     *                         as defined by the ISO 4217 standard (three characters).
+     *                         E.g. 'EUR', 'USD', 'PLN'. Optional.
+     *                         Defaults to $def_currency defined in the language class.
+     *
+     * @param string $decimalPoint  Decimal mark symbol
+     *                         E.g. '.', ','. Optional.
+     *                         Defaults to $decimalPoint defined in the language class.
+     *
+     * @return string  The corresponding word representation
+     *
+     * @access public
+     * @author Ricardo Dalinger <rdalinger@siu.edu.ar>
+     * @since  PHP 4.2.3
+     * @return string
+     */
+    function toAccountable($num, $locale = 'en_US', $intCurr = '', $decimalPoint = null)
+    {
+        $ret = $num;
+
+        $classname = self::loadLocale($locale, 'toAccountableWords');
+
+        $obj = new $classname;
+
+        if (is_null($decimalPoint)) {
+            $decimalPoint = $obj->decimalPoint;
+        }
+
+        // round if a float is passed, use Math_BigInteger otherwise
+        if (is_float($num)) {
+            $num = round($num, 2);
+        }
+
+        $num = $obj->normalizeNumber($num, $decimalPoint);
+
+        if (strpos($num, $decimalPoint) === false) {
+            return trim($obj->toAccountableWords($intCurr, $num));
+        }
+
+        $currency = explode($decimalPoint, $num, 2);
+
+        $len = strlen($currency[1]);
+
+        if ($len == 1) {
+            // add leading zero
+            $currency[1] .= '0';
+        } elseif ($len > 2) {
+            // get the 3rd digit after the comma
+            $round_digit = substr($currency[1], 2, 1);
+            
+            // cut everything after the 2nd digit
+            $currency[1] = substr($currency[1], 0, 2);
+            
+            if ($round_digit >= 5) {
+                // round up without losing precision
+                include_once "Math/BigInteger.php";
+
+                $int = new Math_BigInteger(join($currency));
+                $int = $int->add(new Math_BigInteger(1));
+                $int_str = $int->toString();
+
+                $currency[0] = substr($int_str, 0, -2);
+                $currency[1] = substr($int_str, -2);
+
+                // check if the rounded decimal part became zero
+                if ($currency[1] == '00') {
+                    $currency[1] = false;
+                }
+            }
+        }
+
+        return trim($obj->toAccountableWords($intCurr, $currency[0], $currency[1]));
+    }
+    // }}}
+
+
     // {{{ getLocales()
     /**
      * Lists available locales for Numbers_Words

--- a/Numbers/Words.php
+++ b/Numbers/Words.php
@@ -261,7 +261,7 @@ class Numbers_Words
         $num = $obj->normalizeNumber($num, $decimalPoint);
 
         if (strpos($num, $decimalPoint) === false) {
-            return trim($obj->toAccountableWords($intCurr, $num));
+            return trim($obj->toAccountableWords($intCurr, $num, false, false, ($intCurr == '')));
         }
 
         $currency = explode($decimalPoint, $num, 2);
@@ -296,7 +296,7 @@ class Numbers_Words
             }
         }
 
-        return trim($obj->toAccountableWords($intCurr, $currency[0], $currency[1], false));
+        return trim($obj->toAccountableWords($intCurr, $currency[0], $currency[1], false, ($intCurr == '')));
     }
     // }}}
 

--- a/Numbers/Words/Locale/es/AR.php
+++ b/Numbers/Words/Locale/es/AR.php
@@ -508,6 +508,8 @@ class Numbers_Words_Locale_es_AR extends Numbers_Words
                 $ret = $curr_names[0][0];
             }
             $ret .= $this->_sep;
+        } else {
+            $ret = '';
         }
 
         $ret .= trim($this->_toWords($decimal));

--- a/Numbers/Words/Locale/es/AR.php
+++ b/Numbers/Words/Locale/es/AR.php
@@ -465,5 +465,61 @@ class Numbers_Words_Locale_es_AR extends Numbers_Words
     // }}}
 
 
+    // {{{ toAccountableWords()
 
+    /**
+     * Converts a currency value to its word representation with or without currency symbol
+     * (with monetary units and cents in short form) in Agentinian Spanish language
+     *
+     * @param integer $int_curr         An international currency symbol
+     *                                  as defined by the ISO 4217 standard (three characters)
+     * @param integer $decimal          A money total amount without fraction part (e.g. amount of dollars)
+     * @param integer $fraction         Fractional part of the money amount (e.g. amount of cents)
+     *                                  Optional. Defaults to false.
+     * @param integer $convert_fraction Convert fraction to words (left as numeric if set to false).
+     *                                  Optional. Defaults to true.
+     *
+     * @param boolean $avoid_curr_name  Avoids international currency symbol
+     *
+     * @return string  The corresponding word representation for the currency
+     *
+     * @access public
+     * @author Ricardo Dalinger
+     */
+    function toAccountableWords($int_curr, $decimal, $fraction = false, $convert_fraction = true, $avoid_curr_name=false)
+    {
+        if ($avoid_curr_name === false) {
+            $int_curr = strtoupper($int_curr);
+            if (!isset($this->_currency_names[$int_curr])) {
+                $int_curr = $this->def_currency;
+            }
+
+            $curr_names = $this->_currency_names[$int_curr];
+
+            $lev = ($decimal == 1) ? 0 : 1;
+            if ($lev > 0) {
+                if (count($curr_names[0]) > 1) {
+                    $ret = $curr_names[0][$lev];
+                } else {
+                    $ret = $curr_names[0][0] . 's';
+                }
+
+            } else {
+                $ret = $curr_names[0][0];
+            }
+            $ret .= $this->_sep;
+        }
+
+        $ret .= trim($this->_toWords($decimal));
+
+        if ($fraction !== false) {
+            if ($convert_fraction) {
+                $ret .= $this->_sep .'con'. $this->_sep . trim($this->_toWords($fraction)) .'/100';
+            } else {
+                $ret .= $this->_sep .'con'. $this->_sep . $fraction . '/100';
+            }
+        }
+        return $ret;
+    }
+    // }}}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "pear/numbers_words",
-    "description": "Allows converting numbers written in arabic digits to words in several languages. You can convert an integer between -infinity and infinity.",
+    "name": "siu-toba/numbers_words",
+    "description": "Fork from pear/Numbers_Words with added support to short cents form (xx/100) in Spanish languaje.",
     "type": "library",
     "keywords": [
         "numbers"
     ],
-    "homepage": "https://github.com/pear/Numbers_Words",
+    "homepage": "https://github.com/SIU-Toba/Numbers_Words",
     "license": "PHP-3.01",
     "authors": [
         {

--- a/tests/SpanishArTest.php
+++ b/tests/SpanishArTest.php
@@ -1,0 +1,152 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4 autoindent: */
+/**
+ * Numbers_Words class extension to spell numbers in Spanish (Castellano).
+ *
+ * PHP versions 4 and 5
+ *
+ * LICENSE: This source file is subject to version 3.01 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_01.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   Numbers
+ * @package    Numbers_Words
+ * @author     Xavier Noguer <xnoguer.php@gmail.com>
+ * @copyright  1997-2008 The PHP Group
+ * @license    http://www.php.net/license/3_01.txt  PHP License 3.01
+ * @version    SVN: $Id$
+ * @link       http://pear.php.net/package/Numbers_Words
+ */
+
+require_once 'Numbers/Words.php';
+
+class Numbers_Words_SpanishArTest extends PHPUnit_Framework_TestCase
+{
+
+    var $handle;
+
+    function setUp()
+    {
+        $this->handle = new Numbers_Words();
+    }
+
+    /**
+     * Testing numbers between 0 and 9
+     */
+    function testDigits()
+    {
+        $digits = array('cero',
+                        'uno',
+                        'dos',
+                        'tres',
+                        'cuatro',
+                        'cinco',
+                        'seis',
+                        'siete',
+                        'ocho',
+                        'nueve'
+                       );
+        for ($i = 0; $i < 10; $i++)
+        {
+            $number = $this->handle->toWords($i, 'es_AR');
+            $this->assertEquals($digits[$i], $number);
+        }
+    }
+
+    /**
+     * Testing numbers between 10 and 99
+     */
+    function testTens()
+    {
+        $tens = array(11 => 'once',
+                      12 => 'doce',
+                      16 => 'dieciseis',
+                      19 => 'diecinueve',
+                      20 => 'veinte',
+                      21 => 'veintiuno',
+                      26 => 'veintiseis',
+                      30 => 'treinta',
+                      31 => 'treinta y uno',
+                      40 => 'cuarenta',
+                      43 => 'cuarenta y tres',
+                      50 => 'cincuenta',
+                      55 => 'cincuenta y cinco',
+                      60 => 'sesenta',
+                      67 => 'sesenta y siete',
+                      70 => 'setenta',
+                      79 => 'setenta y nueve'
+                     );
+        foreach ($tens as $number => $word) {
+            $this->assertEquals($word, $this->handle->toWords($number, 'es_AR'));
+        }
+    }
+
+    /**
+     * Testing numbers between 100 and 999
+     */
+    function testHundreds()
+    {
+        $hundreds = array(100 => 'cien',
+                          101 => 'ciento uno',
+                          199 => 'ciento noventa y nueve',
+                          203 => 'doscientos tres',
+                          287 => 'doscientos ochenta y siete',
+                          300 => 'trescientos',
+                          356 => 'trescientos cincuenta y seis',
+                          410 => 'cuatrocientos diez',
+                          434 => 'cuatrocientos treinta y cuatro',
+                          578 => 'quinientos setenta y ocho',
+                          689 => 'seiscientos ochenta y nueve',
+                          729 => 'setecientos veintinueve',
+                          894 => 'ochocientos noventa y cuatro',
+                          999 => 'novecientos noventa y nueve'
+                         );
+        foreach ($hundreds as $number => $word) {
+            $this->assertEquals($word, $this->handle->toWords($number, 'es_AR'));
+        }
+    }
+
+    /**
+     * Testing numbers between 1000 and 9999
+     */
+    function testThousands()
+    {
+        $thousands = array(1000 => 'mil',
+                           1001 => 'mil uno',
+                           1097 => 'mil noventa y siete',
+                           1104 => 'mil ciento cuatro',
+                           1243 => 'mil doscientos cuarenta y tres',
+                           2385 => 'dos mil trescientos ochenta y cinco',
+                           3766 => 'tres mil setecientos sesenta y seis',
+                           4196 => 'cuatro mil ciento noventa y seis',
+                           5846 => 'cinco mil ochocientos cuarenta y seis',
+                           6459 => 'seis mil cuatrocientos cincuenta y nueve',
+                           7232 => 'siete mil doscientos treinta y dos',
+                           8569 => 'ocho mil quinientos sesenta y nueve',
+                           9539 => 'nueve mil quinientos treinta y nueve'
+                          );
+        foreach ($thousands as $number => $word) {
+            $this->assertEquals($word, $this->handle->toWords($number, 'es_AR'));
+        }
+    }
+
+    function testDecimal()
+    {
+        $thousands = array('1000.1' => 'Pesos mil con 10/100',
+                           '1001.25' => 'Pesos mil uno con 25/100',
+                           '1097.34' => 'Pesos mil noventa y siete con 34/100',
+                           '1104.74' => 'Pesos mil ciento cuatro con 74/100',
+                           '1243.78' => 'Pesos mil doscientos cuarenta y tres con 78/100',
+                           '2385.46' => 'Pesos dos mil trescientos ochenta y cinco con 46/100',
+                           '3766.66' => 'Pesos tres mil setecientos sesenta y seis con 66/100',
+                           '4196.13' => 'Pesos cuatro mil ciento noventa y seis con 13/100',
+                           '5846.14' => 'Pesos cinco mil ochocientos cuarenta y seis con 14/100',
+                           '6459.0' => 'Pesos seis mil cuatrocientos cincuenta y nueve con 00/100',
+                          );
+        foreach ($thousands as $number => $word) {
+            $this->assertEquals($word, $this->handle->toAccountable($number, 'es_AR'));
+        }
+    }
+}

--- a/tests/SpanishArTest.php
+++ b/tests/SpanishArTest.php
@@ -134,8 +134,26 @@ class Numbers_Words_SpanishArTest extends PHPUnit_Framework_TestCase
 
     function testDecimal()
     {
-        $thousands = array('1000.1' => 'Pesos mil con 10/100',
-                           '1001.25' => 'Pesos mil uno con 25/100',
+        $thousands = array('1000.1' => 'mil con 10/100',
+                           '1001.25' => 'mil uno con 25/100',
+                           '1097.34' => 'mil noventa y siete con 34/100',
+                           '1104.74' => 'mil ciento cuatro con 74/100',
+                           '1243.78' => 'mil doscientos cuarenta y tres con 78/100',
+                           '2385.46' => 'dos mil trescientos ochenta y cinco con 46/100',
+                           '3766.66' => 'tres mil setecientos sesenta y seis con 66/100',
+                           '4196.13' => 'cuatro mil ciento noventa y seis con 13/100',
+                           '5846.14' => 'cinco mil ochocientos cuarenta y seis con 14/100',
+                           '6459.0' => 'seis mil cuatrocientos cincuenta y nueve con 00/100',
+                          );
+        foreach ($thousands as $number => $word) {
+            $this->assertEquals($word, $this->handle->toAccountable($number, 'es_AR'));
+        }
+    }
+
+    function testDecimalCurrency()
+    {
+        $thousands = array('1000.01' => 'Pesos mil con 01/100',
+                           '1001.2' => 'Pesos mil uno con 20/100',
                            '1097.34' => 'Pesos mil noventa y siete con 34/100',
                            '1104.74' => 'Pesos mil ciento cuatro con 74/100',
                            '1243.78' => 'Pesos mil doscientos cuarenta y tres con 78/100',
@@ -146,7 +164,7 @@ class Numbers_Words_SpanishArTest extends PHPUnit_Framework_TestCase
                            '6459.0' => 'Pesos seis mil cuatrocientos cincuenta y nueve con 00/100',
                           );
         foreach ($thousands as $number => $word) {
-            $this->assertEquals($word, $this->handle->toAccountable($number, 'es_AR'));
+            $this->assertEquals($word, $this->handle->toAccountable($number, 'es_AR', 'ARS'));
         }
     }
 }


### PR DESCRIPTION
Added methods to represent format U$S 12.37 => twelve dollars with 37/100.
Used on contracts and accountability, currency symbol could be avoided if necessary. 
Only es_AR locale done.
