### PR TITLE
fix typo in cs translation

### DIFF
--- a/Numbers/Words/Locale/cs.php
+++ b/Numbers/Words/Locale/cs.php
@@ -126,7 +126,7 @@ class Numbers_Words_Locale_cs extends Numbers_Words
      * @access private
      */
     var $_hundreds = array(
-        0 => 'sto', 'stý', 'sta', 'set'
+        0 => 'sto', 'stě', 'sta', 'set'
     );
 
     /**


### PR DESCRIPTION
Right form is 'stě', 'stý' is used in ordinal numbers.
https://cs.wiktionary.org/wiki/dv%C4%9B_st%C4%9B