### PR TITLE
Change French translation for 70 to 79 & 90 to 99

### DIFF
--- a/Numbers/Words/Locale/fr/BE.php
+++ b/Numbers/Words/Locale/fr/BE.php
@@ -83,6 +83,7 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
         50=>'cinquante',// 50
         60=>'soixante', // 60
         70=>'septante', // 70
+        80=>'quatre-vingt', // 80
         90=>'nonante',  // 90
        100=>'cent'      // 100
     );
@@ -335,6 +336,16 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
                     $ret .= $this->_misc_numbers[10].'-'.$this->_digits[$e];
                 }
                 $e = 0;
+            } elseif($d==7 || $d==9) {
+                //70 is same as 60 + 10, like wise till 76, same logic to be followed for 90 as well
+                if ($e<=6) {
+                    $ret .= $this->_misc_numbers[($d-1)*10].'-'.$this->_misc_numbers[$e+10];
+                    if($e != 1) $e = 0;
+                } else {
+                    //for 77 to 79, 77 is 60+10+7 like wise for 78 and 79
+                    $ret .= $this->_misc_numbers[($d-1)*10].'-'.$this->_misc_numbers[10].'-'.$this->_digits[$e];
+                    $e = 0;
+                }
             } elseif ($d==8) {
                 $ret .= $this->_digits[4].$this->_dash.$this->_misc_numbers[20];
                 $resto = $d*10+$e-80;


### PR DESCRIPTION
For 70 till 76, we need to show 60+10 for 70, likewise 71 should be shown like 60+11
for 77 to 79, the logic is 77 - 60+10+7

Please refer to below:

70	Septante / Soixante-dix
71	Septante et un / Soixante et onze
72	Septante-deux / Soixante-douze
73	Septante-trois / Soixante-treize
74	Septante-quatre / Soixante-quatorze
75	Septante-cinq / Soixante-quinze
76	Septante-six / Soixante-seize
77	Septante-sept / Soixante-dix-sept
78	Septante-huit / Soixante-dix-huit
79	Septante-neuf / Soixante-dix-neuf

90	Nonante / quatre-vingt-dix
91	Nonante et un /quantre-vingt-onze
92	Nonante-deux / Quatre-vingt-douze
93	Nonante-trois / Quatre-vingt-treize
94	Nonante-quatre / Quatre-vingt-quatorze
95	Nonante-cinq / Quatre-vingt-quinze
96	Nonante-six / Quatre-vingt-seize
97	Nonante-sept / Quatre-vingt-dix-sept
98	Nonante-huit / Quatre-vingt-dix-huit
99	Nonante-neuf / Quatre-vingt-dix-neuf