### PR TITLE
Change french translation for 70 to 79 & 90 to 99

### DIFF
--- a/Numbers/Words/Locale/fr/BE.php
+++ b/Numbers/Words/Locale/fr/BE.php
@@ -83,6 +83,7 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
         50=>'cinquante',// 50
         60=>'soixante', // 60
         70=>'septante', // 70
+        80=>'quatre-vingt', // 80
         90=>'nonante',  // 90
        100=>'cent'      // 100
     );
@@ -335,6 +336,21 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
                     $ret .= $this->_misc_numbers[10].'-'.$this->_digits[$e];
                 }
                 $e = 0;
+            elseif ($d==7 || $d==9) {
+                //70 is same as 60 + 10, like wise till 76, same logic to be followed for 90 as well
+                if ($e<=6) {
+                    if($e != 1) {
+                        //for ones, below digit logic will take care of adding hyphen(-) or not
+                        $ret .= $this->_misc_numbers[($d-1)*10].'-'.$this->_misc_numbers[$e+10];
+                    } else {
+                        $ret .= $this->_misc_numbers[($d-1)*10];
+                    }
+                    if($e != 1) $e = 0;
+                } else {
+                    //for 77 to 79, 77 is 60+10+7 like wise for 78 and 79
+                    $ret .= $this->_misc_numbers[($d-1)*10].'-'.$this->_misc_numbers[10].'-'.$this->_digits[$e];
+                    $e = 0;
+                }
             } elseif ($d==8) {
                 $ret .= $this->_digits[4].$this->_dash.$this->_misc_numbers[20];
                 $resto = $d*10+$e-80;
@@ -353,13 +369,18 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
         // process the "ones" digit
         if ($e) {
             if ($d) {
-                if ($e==1) {
+                if ($e==1 && $d!=9) { //hyphen should not be added for 91
                     $ret .= $this->_sep.$this->_and.$this->_sep;
                 } else {
                     $ret .= $this->_dash;
                 }
             }
-            $ret .= $this->_digits[$e];
+            //for 71 and 91 we need to show onze(11) instead of un(1)
+            if(($d==7 || $d==9) && $e==1){
+                $ret .= $this->_misc_numbers[$e+10];
+            } else {
+                $ret .= $this->_digits[$e];
+            }
         }
 
         // strip excessive separators

--- a/Numbers/Words/Locale/fr/BE.php
+++ b/Numbers/Words/Locale/fr/BE.php
@@ -369,7 +369,7 @@ class Numbers_Words_Locale_fr_BE extends Numbers_Words
         // process the "ones" digit
         if ($e) {
             if ($d) {
-                if ($e==1 && $d!=9) { //hyphen should not be added for 91
+                if ($e==1 && $d!=9) { //hyphen should be added for 91 only
                     $ret .= $this->_sep.$this->_and.$this->_sep;
                 } else {
                     $ret .= $this->_dash;


### PR DESCRIPTION
For French translations, the values from 70 to 79 and 90 to 99 are incorrect.

For 70 till 76, we need to show 60+10 for 70, likewise 71 should be shown like 60+11
from 77 to 79, the logic is 77 - 60+10+7

Same logic applies for 90 to 99, but one change with 91 is to show with dash quantre-vingt-onze.
For 71 we should show without dash Soixante et onze.